### PR TITLE
improve(career): optimize scroll animation timing for better UX

### DIFF
--- a/app/career/CareerAnimations.tsx
+++ b/app/career/CareerAnimations.tsx
@@ -19,7 +19,7 @@ export function CareerAnimations({ heroContent, restContent }: CareerAnimationsP
       reveals.forEach((element) => {
         const windowHeight = window.innerHeight;
         const elementTop = element.getBoundingClientRect().top;
-        const elementVisible = 150;
+        const elementVisible = 50;
 
         if (elementTop < windowHeight - elementVisible) {
           element.classList.add('opacity-100', 'translate-y-0');
@@ -41,7 +41,10 @@ export function CareerAnimations({ heroContent, restContent }: CareerAnimationsP
           }
         });
       },
-      { threshold: 0.1 },
+      { 
+        threshold: 0.01,
+        rootMargin: "0px 0px -100px 0px"
+      },
     );
 
     const timelineItems = document.querySelectorAll('.timeline-item');

--- a/app/career/config/constants.ts
+++ b/app/career/config/constants.ts
@@ -17,7 +17,7 @@ export const CAREER_CONFIG = {
       'from-emerald-500/10 to-emerald-500/5',
       'from-amber-500/10 to-amber-500/5',
     ],
-    VISIBLE_THRESHOLD: 150,
+    VISIBLE_THRESHOLD: 50,
   },
 
   // Skills level mapping


### PR DESCRIPTION
## Summary
- Change Intersection Observer threshold from 0.1 to 0.01 for earlier trigger
- Add rootMargin "0px 0px -100px 0px" to start animations 100px before element enters viewport
- Reduce manual scroll detection threshold from 150px to 50px for .reveal elements

## Test plan
- [ ] Test career page scroll animations on different screen sizes
- [ ] Verify cards appear earlier during scroll
- [ ] Check performance impact of changes
- [ ] Test both timeline items and reveal elements

Fixes #5

Generated with [Claude Code](https://claude.ai/code)